### PR TITLE
Dark sky caching and migration from joda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   - SONA_USER=snowplow
   - secure: L7GOi+ZrnZww7uig8IJ0kFVuB3aRoXG6aQ04IdngWsarrZiZV7nL9UeRbOeCP2xv+Ni6nT9NrYr8ziGCD29181Jlt6DFQIKZQYXABYoNqypa+7icMb+zGwBQNKwc+uEHWKnVZpWzPvCkT2tMe1ovyGvyXOeupRLg7c+c+Ew84I0=
 script:
-- sbt coverage test coverageReport
+- sbt ++$TRAVIS_SCALA_VERSION coverage test coverageReport
 deploy:
   skip_cleanup: true
   provider: script

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,6 @@ lazy val root = project
   .settings(BuildSettings.formatting)
   .settings(
     libraryDependencies ++= Seq(
-      Dependencies.Libraries.jodaTime,
       Dependencies.Libraries.circeGeneric,
       Dependencies.Libraries.circeParser,
       Dependencies.Libraries.circeExtras,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,9 +15,6 @@ import sbt._
 object Dependencies {
 
   object V {
-    // Java
-    val jodaTime    = "2.10"
-    // Scala
     val circe       = "0.9.3"
     val hammock     = "0.8.5"
     val lruMap      = "0.1.0"
@@ -26,9 +23,6 @@ object Dependencies {
   }
 
   object Libraries {
-    // Java
-    val jodaTime        = "joda-time"             %  "joda-time"            % V.jodaTime
-    // Scala
     val circeGeneric    = "io.circe"              %% "circe-generic"        % V.circe
     val circeParser     = "io.circe"              %% "circe-parser"         % V.circe
     val circeExtras     = "io.circe"              %% "circe-generic-extras" % V.circe

--- a/src/main/scala/com.snowplowanalytics/weather/Implicits.scala
+++ b/src/main/scala/com.snowplowanalytics/weather/Implicits.scala
@@ -37,7 +37,7 @@ object Implicits {
      * @param d joda time containing all information
      * @return Unix epoch timestamp
      */
-    implicit def optDateToInt(d: DateTime): OptArg[Int] = Some((d.getMillis / 1000).toInt)
+    implicit def optDateToLong(d: DateTime): OptArg[Long] = Some(d.getMillis / 1000)
   }
 
   /**
@@ -56,5 +56,14 @@ object Implicits {
    * @return empty Map if v is None, Map(k -> v) otherwise
    */
   implicit def pairIntToMap(pair: (String, OptArg[Int])): Map[String, String] =
+    pair._2.map(v => Map(pair._1 -> v.toString)).getOrElse(Map.empty)
+
+  /**
+   * Addition to `pairToMap` specified on Integers
+   *
+   * @param pair tuple with optional second element
+   * @return empty Map if v is None, Map(k -> v) otherwise
+   */
+  implicit def pairLongToMap(pair: (String, OptArg[Long])): Map[String, String] =
     pair._2.map(v => Map(pair._1 -> v.toString)).getOrElse(Map.empty)
 }

--- a/src/main/scala/com.snowplowanalytics/weather/Implicits.scala
+++ b/src/main/scala/com.snowplowanalytics/weather/Implicits.scala
@@ -12,11 +12,11 @@
  */
 package com.snowplowanalytics.weather
 
+// Java
+import java.time.ZonedDateTime
+
 // Scala
 import scala.language.implicitConversions
-
-// Joda
-import org.joda.time.DateTime
 
 object Implicits {
 
@@ -37,7 +37,7 @@ object Implicits {
      * @param d joda time containing all information
      * @return Unix epoch timestamp
      */
-    implicit def optDateToLong(d: DateTime): OptArg[Long] = Some(d.getMillis / 1000)
+    implicit def optDateToLong(d: ZonedDateTime): OptArg[Long] = Some(d.toEpochSecond)
   }
 
   /**
@@ -59,7 +59,7 @@ object Implicits {
     pair._2.map(v => Map(pair._1 -> v.toString)).getOrElse(Map.empty)
 
   /**
-   * Addition to `pairToMap` specified on Integers
+   * Addition to `pairToMap` specified on Longs
    *
    * @param pair tuple with optional second element
    * @return empty Map if v is None, Map(k -> v) otherwise

--- a/src/main/scala/com.snowplowanalytics/weather/package.scala
+++ b/src/main/scala/com.snowplowanalytics/weather/package.scala
@@ -16,8 +16,8 @@ import hammock.Uri
 
 package object weather {
 
-  type Timestamp = Int
-  type Day       = Int // 0:00:00 timestamp of day
+  type Timestamp = Long
+  type Day       = Long // 0:00:00 timestamp of day
 
   trait WeatherRequest {
     def constructQuery(baseUri: Uri, apiKey: String): Uri

--- a/src/main/scala/com.snowplowanalytics/weather/providers/darksky/DarkSkyCacheClient.scala
+++ b/src/main/scala/com.snowplowanalytics/weather/providers/darksky/DarkSkyCacheClient.scala
@@ -1,3 +1,15 @@
+/*
+ * Copyright (c) 2015-2018 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
 package com.snowplowanalytics.weather
 package providers.darksky
 
@@ -11,6 +23,7 @@ import Errors.WeatherError
 class DarkSkyCacheClient[F[_]] private[darksky] (cache: Cache[F, DarkSkyResponse], transport: Transport[F])
     extends DarkSkyClient[F](transport) {
 
+  /** nth part of 1 to which latitude and longitude will be rounded */
   val geoPrecision: Int = cache.geoPrecision
 
   /**

--- a/src/main/scala/com.snowplowanalytics/weather/providers/darksky/DarkSkyCacheClient.scala
+++ b/src/main/scala/com.snowplowanalytics/weather/providers/darksky/DarkSkyCacheClient.scala
@@ -1,0 +1,42 @@
+package com.snowplowanalytics.weather
+package providers.darksky
+
+// Java
+import java.time.ZonedDateTime
+
+// This library
+import Responses.DarkSkyResponse
+import Errors.WeatherError
+
+class DarkSkyCacheClient[F[_]] private[darksky] (cache: Cache[F, DarkSkyResponse], transport: Transport[F])
+    extends DarkSkyClient[F](transport) {
+
+  val geoPrecision: Int = cache.geoPrecision
+
+  /**
+   * Gets DarkSkyResponse for the specified date (alignes time to midnight) from the cache,
+   * if not found, then performs the request
+   * == IMPORTANT ==
+   * Returned DarkSkyResponse's `currently` field excluded, because the time is always aligned to midnight
+   *
+   * @param latitude The latitude of a location. Positive is north, negative is south.
+   * @param longitude The longitude of a location. Positive is east, negative is west.
+   * @param dateTime zoned datetime, time is aligned to midnight
+   * @return either weather error or dark sky response, wrapper in effect type F
+   */
+  def cachingTimeMachine(latitude: Float,
+                         longitude: Float,
+                         dateTime: ZonedDateTime,
+                         exclude: List[BlockType] = List.empty[BlockType],
+                         extend: Boolean          = false,
+                         lang: Option[String]     = None,
+                         units: Option[Units]     = None): F[Either[WeatherError, DarkSkyResponse]] =
+    cache.getCachedOrRequest(latitude, longitude, dateTime)(doRequest(exclude, extend, lang, units))
+
+  private def doRequest(exclude: List[BlockType], extend: Boolean, lang: Option[String], units: Option[Units])(
+    latitude: Float,
+    longitude: Float,
+    dateTime: ZonedDateTime): F[Either[WeatherError, DarkSkyResponse]] =
+    timeMachine(latitude, longitude, dateTime, (List(BlockType.currently) ++ exclude).distinct, extend, lang, units)
+
+}

--- a/src/main/scala/com.snowplowanalytics/weather/providers/darksky/Responses.scala
+++ b/src/main/scala/com.snowplowanalytics/weather/providers/darksky/Responses.scala
@@ -13,6 +13,8 @@
 package com.snowplowanalytics.weather
 package providers.darksky
 
+import cats.syntax.either._ // 2.11.x
+
 import io.circe.Decoder
 import io.circe.generic.JsonCodec
 import io.circe.generic.extras.semiauto.deriveUnwrappedDecoder

--- a/src/main/scala/com.snowplowanalytics/weather/providers/openweather/OpenWeatherMap.scala
+++ b/src/main/scala/com.snowplowanalytics/weather/providers/openweather/OpenWeatherMap.scala
@@ -27,7 +27,7 @@ import cats.syntax.monadError._
 import com.snowplowanalytics.lrumap.LruMap
 
 // This library
-import CacheUtils.CacheKey
+import Cache.CacheKey
 import Errors.{InvalidConfigurationError, WeatherError}
 import Responses.History
 
@@ -92,6 +92,7 @@ object OpenWeatherMap {
       .ensure(InvalidConfigurationError("geoPrecision must be greater than 0"))(_ => geoPrecision > 0)
       .ensure(InvalidConfigurationError("cacheSize must be greater than 0"))(_ => cacheSize > 0)
       .flatMap(_ => LruMap.create[F, CacheKey, Either[WeatherError, History]](cacheSize))
-      .map(cache => new OwmCacheClient(cache, geoPrecision, transport))
+      .map(lruMap => new Cache(lruMap, geoPrecision))
+      .map(cache => new OwmCacheClient(cache, transport))
 
 }

--- a/src/main/scala/com.snowplowanalytics/weather/providers/openweather/OwmClient.scala
+++ b/src/main/scala/com.snowplowanalytics/weather/providers/openweather/OwmClient.scala
@@ -38,8 +38,8 @@ class OwmClient[F[_]] private[openweather] (transport: Transport[F]) {
    * @return either error or history wrapped in `F`
    */
   def historyById(id: Int,
-                  start: OptArg[Int]                  = None,
-                  end: OptArg[Int]                    = None,
+                  start: OptArg[Long]                 = None,
+                  end: OptArg[Long]                   = None,
                   cnt: OptArg[Int]                    = None,
                   measure: OptArg[Api.Measures.Value] = None): F[Either[WeatherError, History]] = {
     val request = OwmHistoryRequest("city",
@@ -65,8 +65,8 @@ class OwmClient[F[_]] private[openweather] (transport: Transport[F]) {
    */
   def historyByName(name: String,
                     country: OptArg[String]             = None,
-                    start: OptArg[Int]                  = None,
-                    end: OptArg[Int]                    = None,
+                    start: OptArg[Long]                 = None,
+                    end: OptArg[Long]                   = None,
                     cnt: OptArg[Int]                    = None,
                     measure: OptArg[Api.Measures.Value] = None): F[Either[WeatherError, History]] = {
     val query = name + country.map("," + _).getOrElse("")
@@ -93,8 +93,8 @@ class OwmClient[F[_]] private[openweather] (transport: Transport[F]) {
    */
   def historyByCoords(lat: Float,
                       lon: Float,
-                      start: OptArg[Int]                  = None,
-                      end: OptArg[Int]                    = None,
+                      start: OptArg[Long]                 = None,
+                      end: OptArg[Long]                   = None,
                       cnt: OptArg[Int]                    = None,
                       measure: OptArg[Api.Measures.Value] = None): F[Either[WeatherError, History]] = {
     val request = OwmHistoryRequest("city",

--- a/src/main/scala/com.snowplowanalytics/weather/providers/openweather/Responses.scala
+++ b/src/main/scala/com.snowplowanalytics/weather/providers/openweather/Responses.scala
@@ -14,6 +14,8 @@ package com.snowplowanalytics.weather
 package providers.openweather
 
 // circe
+import java.time.ZonedDateTime
+
 import io.circe.generic.JsonCodec
 
 // This library
@@ -38,14 +40,14 @@ object Responses {
 
   @JsonCodec
   final case class Forecast(cnt: BigInt, cod: String, list: List[Weather]) extends OwmResponse {
-    def pickCloseIn(timestamp: Long): Either[WeatherError, Weather] =
-      pickClosestWeather(list, timestamp)
+    def pickCloseIn(dateTime: ZonedDateTime): Either[WeatherError, Weather] =
+      pickClosestWeather(list, dateTime.toEpochSecond)
   }
 
   @JsonCodec
   final case class History(cnt: BigInt, cod: String, list: List[Weather]) extends OwmResponse {
-    def pickCloseIn(timestamp: Long): Either[WeatherError, Weather] =
-      pickClosestWeather(list, timestamp)
+    def pickCloseIn(dateTime: ZonedDateTime): Either[WeatherError, Weather] =
+      pickClosestWeather(list, dateTime.toEpochSecond)
   }
 
   // DETAILS

--- a/src/main/scala/com.snowplowanalytics/weather/providers/openweather/Responses.scala
+++ b/src/main/scala/com.snowplowanalytics/weather/providers/openweather/Responses.scala
@@ -38,13 +38,13 @@ object Responses {
 
   @JsonCodec
   final case class Forecast(cnt: BigInt, cod: String, list: List[Weather]) extends OwmResponse {
-    def pickCloseIn(timestamp: Int): Either[WeatherError, Weather] =
+    def pickCloseIn(timestamp: Long): Either[WeatherError, Weather] =
       pickClosestWeather(list, timestamp)
   }
 
   @JsonCodec
   final case class History(cnt: BigInt, cod: String, list: List[Weather]) extends OwmResponse {
-    def pickCloseIn(timestamp: Int): Either[WeatherError, Weather] =
+    def pickCloseIn(timestamp: Long): Either[WeatherError, Weather] =
       pickClosestWeather(list, timestamp)
   }
 
@@ -99,7 +99,7 @@ object Responses {
    * @param timestamp original integer
    * @return close neighbour
    */
-  private[openweather] def pickClosestWeather(list: List[Weather], timestamp: Int): Either[WeatherError, Weather] =
+  private[openweather] def pickClosestWeather(list: List[Weather], timestamp: Long): Either[WeatherError, Weather] =
     if (timestamp < 1) Left(InternalError("Timestamp should be greater than 0"))
     else
       pickClosest(list, timestamp, (st: Weather) => (st.dt.toInt, st))
@@ -114,7 +114,7 @@ object Responses {
    * @param transform function to derive index (timestamp) out of object (weather stamp)
    * @return closest object for some index
    */
-  private[openweather] def pickClosest[A](list: List[A], index: Int, transform: A => (Int, A)): Option[A] =
+  private[openweather] def pickClosest[A](list: List[A], index: Long, transform: A => (Int, A)): Option[A] =
     list
       .map(transform)
       .sortBy(x => Math.abs(index - x._1))

--- a/src/test/scala/com.snowplowanalytics.weather/providers/GeoPrecisionSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.weather/providers/GeoPrecisionSpec.scala
@@ -10,11 +10,12 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.weather.providers.openweather
+package com.snowplowanalytics.weather
+package providers
 
-import org.specs2.{ScalaCheck, Specification}
 import org.scalacheck.Arbitrary
 import org.scalacheck.Prop.forAll
+import org.specs2.{ScalaCheck, Specification}
 
 class GeoPrecisionSpec extends Specification with ScalaCheck {
   def is = s2"""
@@ -40,26 +41,26 @@ class GeoPrecisionSpec extends Specification with ScalaCheck {
     test 1/5                                       $e10
                                                    """
 
-  def e1 = CacheUtils.roundCoordinate(1.321f, 1) must beEqualTo(1.0f)
-  def e2 = CacheUtils.roundCoordinate(1.921f, 1) must beEqualTo(2.0f)
-  def e3 = CacheUtils.roundCoordinate(1.321f, 2) must beEqualTo(1.5f)
-  def e4 = CacheUtils.roundCoordinate(2.6f, 2) must beEqualTo(2.5f)
-  def e5 = CacheUtils.roundCoordinate(2.85321f, 2) must beEqualTo(3.0f)
-  def e6 = CacheUtils.roundCoordinate(7.312f, 5) must beEqualTo(7.4f)
-  def e7 = CacheUtils.roundCoordinate(7.8001f, 5) must beEqualTo(7.8f)
+  def e1 = Cache.roundCoordinate(1.321f, 1) must beEqualTo(1.0f)
+  def e2 = Cache.roundCoordinate(1.921f, 1) must beEqualTo(2.0f)
+  def e3 = Cache.roundCoordinate(1.321f, 2) must beEqualTo(1.5f)
+  def e4 = Cache.roundCoordinate(2.6f, 2) must beEqualTo(2.5f)
+  def e5 = Cache.roundCoordinate(2.85321f, 2) must beEqualTo(3.0f)
+  def e6 = Cache.roundCoordinate(7.312f, 5) must beEqualTo(7.4f)
+  def e7 = Cache.roundCoordinate(7.8001f, 5) must beEqualTo(7.8f)
 
   // Rounding arbitrary floats
   val sensibleFloat = // we want omit big exponents
     Arbitrary.arbitrary[Float] suchThat (f => (f > -180.0) && (f < 180.0))
 
   def e8 = forAll(sensibleFloat) { f: Float =>
-    CacheUtils.roundCoordinate(f, 1).toString must endWith(".0")
+    Cache.roundCoordinate(f, 1).toString must endWith(".0")
   }
   def e9 = forAll(sensibleFloat) { f: Float =>
-    CacheUtils.roundCoordinate(f, 2).toString must endWith(".0") or endWith(".5")
+    Cache.roundCoordinate(f, 2).toString must endWith(".0") or endWith(".5")
   }
   def e10 = forAll(sensibleFloat) { f: Float =>
-    CacheUtils
+    Cache
       .roundCoordinate(f, 5)
       .toString must endWith(".0") or endWith(".2") or endWith(".4") or endWith(".6") or endWith(".8")
   }

--- a/src/test/scala/com.snowplowanalytics.weather/providers/darksky/DarkSkyCacheSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.weather/providers/darksky/DarkSkyCacheSpec.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2015-2018 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.weather
+package providers.darksky
+
+// cats
+import java.time.ZonedDateTime
+
+import cats.effect.IO
+import cats.syntax.either._
+
+// tests
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.Specification
+import org.specs2.mock.Mockito
+import org.specs2.matcher.DisjunctionMatchers
+
+// This library
+import Errors.{InvalidConfigurationError, TimeoutError}
+import Requests.DarkSkyRequest
+import Responses.DarkSkyResponse
+
+// Mock transport which returns predefined responses
+class DarkSkyCacheSpec(implicit val ec: ExecutionEnv) extends Specification with Mockito with DisjunctionMatchers {
+  def is =
+    s2"""
+
+  Test cache specification
+
+    do not bother server on identical requests $e1
+    do not bother server on similar requests $e4
+    retry request on timeout error $e2
+    check geoPrecision $e5
+    make requests again after full cache $e3
+    throw exception for invalid precision $e6
+    throw exception for invalid cache size $e7
+  """
+
+  val exampleResponse: IO[Right[TimeoutError, DarkSkyResponse]] =
+    IO.pure(Right(DarkSkyResponse(0f, 0f, "", None, None, None, None, None, None)))
+  val timeoutErrorResponse: IO[Either[TimeoutError, DarkSkyResponse]] =
+    IO.pure(TimeoutError("java.util.concurrent.TimeoutException: Futures timed out after [1 second]").asLeft)
+
+  def e1 = {
+    val transport = mock[Transport[IO]].defaultReturn(exampleResponse)
+    val action = for {
+      client <- DarkSky.cacheClient(1, 1, transport)
+      _      <- client.cachingTimeMachine(4.44f, 3.33f, ZonedDateTime.now())
+      _      <- client.cachingTimeMachine(4.44f, 3.33f, ZonedDateTime.now())
+      _      <- client.cachingTimeMachine(4.44f, 3.33f, ZonedDateTime.now())
+    } yield ()
+    action.unsafeRunSync()
+    there.was(1.times(transport).receive(any[DarkSkyRequest])(any()))
+  }
+
+  def e2 = {
+    val transport = mock[TimeoutHttpTransport[IO]]
+    transport
+      .receive[DarkSkyResponse](any[DarkSkyRequest])(any())
+      .returns(timeoutErrorResponse)
+      .thenReturn(exampleResponse)
+
+    val action = for {
+      client <- DarkSky.cacheClient(2, 1, transport)
+      _      <- client.cachingTimeMachine(4.44f, 3.33f, ZonedDateTime.now())
+      _      <- client.cachingTimeMachine(4.44f, 3.33f, ZonedDateTime.now())
+    } yield ()
+    action.unsafeRunSync()
+    there.was(2.times(transport).receive(any[DarkSkyRequest])(any()))
+  }
+
+  def e3 = {
+    val transport = mock[Transport[IO]].defaultReturn(exampleResponse)
+    val action = for {
+      client <- DarkSky.cacheClient(2, 1, transport)
+      _      <- client.cachingTimeMachine(4.44f, 3.33f, ZonedDateTime.now())
+      _      <- client.cachingTimeMachine(6.44f, 3.33f, ZonedDateTime.now())
+      _      <- client.cachingTimeMachine(8.44f, 3.33f, ZonedDateTime.now())
+      _      <- client.cachingTimeMachine(4.44f, 3.33f, ZonedDateTime.now())
+    } yield ()
+    action.unsafeRunSync()
+    there.was(4.times(transport).receive(any[DarkSkyRequest])(any()))
+  }
+
+  def e4 = {
+    val transport = mock[Transport[IO]].defaultReturn(exampleResponse)
+    val action = for {
+      client <- DarkSky.cacheClient(1, 1, transport)
+      _      <- client.cachingTimeMachine(10.4f, 32.1f, ZonedDateTime.parse("2015-11-09T12:00:40Z"))
+      _      <- client.cachingTimeMachine(10.1f, 32.312f, ZonedDateTime.parse("2015-11-09T00:06:47Z"))
+      _      <- client.cachingTimeMachine(10.2f, 32.4f, ZonedDateTime.parse("2015-11-09T23:06:47Z"))
+    } yield ()
+    action.unsafeRunSync()
+    there.was(1.times(transport).receive(any[DarkSkyRequest])(any()))
+  }
+
+  def e5 = {
+    val transport = mock[Transport[IO]].defaultReturn(exampleResponse)
+    val action = for {
+      client <- DarkSky.cacheClient(10, 2, transport)
+      _      <- client.cachingTimeMachine(10.8f, 32.1f, ZonedDateTime.parse("2015-11-09T12:00:40Z"))
+      _      <- client.cachingTimeMachine(10.1f, 32.312f, ZonedDateTime.parse("2015-11-09T00:06:47Z"))
+      _      <- client.cachingTimeMachine(10.2f, 32.4f, ZonedDateTime.parse("2015-11-09T23:06:47Z"))
+    } yield ()
+    action.unsafeRunSync()
+    there.was(2.times(transport).receive(any[DarkSkyRequest])(any()))
+  }
+
+  def e6 =
+    DarkSky.cacheClient[IO]("KEY", geoPrecision = 0).unsafeRunSync() must throwA[InvalidConfigurationError]
+
+  def e7 =
+    DarkSky.cacheClient[IO]("KEY", cacheSize = 0).unsafeRunSync() must throwA[InvalidConfigurationError]
+
+}

--- a/src/test/scala/com.snowplowanalytics.weather/providers/openweather/CacheSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.weather/providers/openweather/CacheSpec.scala
@@ -52,9 +52,9 @@ class CacheSpec(implicit val ec: ExecutionEnv) extends Specification with Mockit
     val transport = mock[Transport[IO]].defaultReturn(emptyHistoryResponse)
     val action = for {
       client <- OpenWeatherMap.cacheClient(2, 1, transport)
-      _      <- client.getCachedOrRequest(4.44f, 3.33f, 100)
-      _      <- client.getCachedOrRequest(4.44f, 3.33f, 100)
-      _      <- client.getCachedOrRequest(4.44f, 3.33f, 100)
+      _      <- client.cachingHistoryByCoords(4.44f, 3.33f, 100)
+      _      <- client.cachingHistoryByCoords(4.44f, 3.33f, 100)
+      _      <- client.cachingHistoryByCoords(4.44f, 3.33f, 100)
     } yield ()
     action.unsafeRunSync()
     there.was(1.times(transport).receive(any[OwmRequest])(any()))
@@ -69,8 +69,8 @@ class CacheSpec(implicit val ec: ExecutionEnv) extends Specification with Mockit
 
     val action = for {
       client <- OpenWeatherMap.cacheClient(2, 1, transport)
-      _      <- client.getCachedOrRequest(4.44f, 3.33f, 100)
-      _      <- client.getCachedOrRequest(4.44f, 3.33f, 100)
+      _      <- client.cachingHistoryByCoords(4.44f, 3.33f, 100)
+      _      <- client.cachingHistoryByCoords(4.44f, 3.33f, 100)
     } yield ()
     action.unsafeRunSync()
     there.was(2.times(transport).receive(any[OwmRequest])(any()))
@@ -80,10 +80,10 @@ class CacheSpec(implicit val ec: ExecutionEnv) extends Specification with Mockit
     val transport = mock[Transport[IO]].defaultReturn(emptyHistoryResponse)
     val action = for {
       client <- OpenWeatherMap.cacheClient(2, 1, transport)
-      _      <- client.getCachedOrRequest(4.44f, 3.33f, 100)
-      _      <- client.getCachedOrRequest(6.44f, 3.33f, 100)
-      _      <- client.getCachedOrRequest(8.44f, 3.33f, 100)
-      _      <- client.getCachedOrRequest(4.44f, 3.33f, 100)
+      _      <- client.cachingHistoryByCoords(4.44f, 3.33f, 100)
+      _      <- client.cachingHistoryByCoords(6.44f, 3.33f, 100)
+      _      <- client.cachingHistoryByCoords(8.44f, 3.33f, 100)
+      _      <- client.cachingHistoryByCoords(4.44f, 3.33f, 100)
     } yield ()
     action.unsafeRunSync()
     there.was(4.times(transport).receive(any[OwmRequest])(any()))
@@ -93,9 +93,9 @@ class CacheSpec(implicit val ec: ExecutionEnv) extends Specification with Mockit
     val transport = mock[Transport[IO]].defaultReturn(emptyHistoryResponse)
     val action = for {
       client <- OpenWeatherMap.cacheClient(10, 1, transport)
-      _      <- client.getCachedOrRequest(10.4f, 32.1f, 1447070440) // Nov 9 12:00:40 2015 GMT
-      _      <- client.getCachedOrRequest(10.1f, 32.312f, 1447063607) // Nov 9 10:06:47 2015 GMT
-      _      <- client.getCachedOrRequest(10.2f, 32.4f, 1447096857) // Nov 9 19:20:57 2015 GMT
+      _      <- client.cachingHistoryByCoords(10.4f, 32.1f, 1447070440) // Nov 9 12:00:40 2015 GMT
+      _      <- client.cachingHistoryByCoords(10.1f, 32.312f, 1447063607) // Nov 9 10:06:47 2015 GMT
+      _      <- client.cachingHistoryByCoords(10.2f, 32.4f, 1447096857) // Nov 9 19:20:57 2015 GMT
     } yield ()
     action.unsafeRunSync()
     there.was(1.times(transport).receive(any[OwmRequest])(any()))
@@ -105,9 +105,9 @@ class CacheSpec(implicit val ec: ExecutionEnv) extends Specification with Mockit
     val transport = mock[Transport[IO]].defaultReturn(emptyHistoryResponse)
     val action = for {
       client <- OpenWeatherMap.cacheClient(10, 2, transport)
-      _      <- client.getCachedOrRequest(10.8f, 32.1f, 1447070440) // Nov 9 12:00:40 2015 GMT
-      _      <- client.getCachedOrRequest(10.1f, 32.312f, 1447063607) // Nov 9 10:06:47 2015 GMT
-      _      <- client.getCachedOrRequest(10.2f, 32.4f, 1447096857) // Nov 9 19:20:57 2015 GMT
+      _      <- client.cachingHistoryByCoords(10.8f, 32.1f, 1447070440) // Nov 9 12:00:40 2015 GMT
+      _      <- client.cachingHistoryByCoords(10.1f, 32.312f, 1447063607) // Nov 9 10:06:47 2015 GMT
+      _      <- client.cachingHistoryByCoords(10.2f, 32.4f, 1447096857) // Nov 9 19:20:57 2015 GMT
     } yield ()
     action.unsafeRunSync()
     there.was(2.times(transport).receive(any[OwmRequest])(any()))

--- a/src/test/scala/com.snowplowanalytics.weather/providers/openweather/ExtractSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.weather/providers/openweather/ExtractSpec.scala
@@ -15,11 +15,14 @@ package com.snowplowanalytics.weather.providers.openweather
 // Scala
 import scala.io.Source
 
-// specs2
-import org.specs2.Specification
+// cats
+import cats.syntax.either._ // 2.11.x
 
 // circe
 import io.circe.parser.parse
+
+// tests
+import org.specs2.Specification
 
 // This library
 import com.snowplowanalytics.weather.Errors._
@@ -45,37 +48,37 @@ class ExtractSpec extends Specification {
 
   def e1 = {
     val weather = parse(Source.fromURL(getClass.getResource("/history.json")).mkString)
-      .flatMap(HttpTransport.extractWeather[History])
+      .flatMap(json => HttpTransport.extractWeather[History](json))
     weather must beRight
   }
 
   def e2 = {
     val weather = parse(Source.fromURL(getClass.getResource("/history-empty.json")).mkString)
-      .flatMap(HttpTransport.extractWeather[History])
+      .flatMap(json => HttpTransport.extractWeather[History](json))
     weather.map(_.list.length) must beRight(0)
   }
 
   def e3 = {
     val weather = parse(Source.fromURL(getClass.getResource("/current.json")).mkString)
-      .flatMap(HttpTransport.extractWeather[Current])
+      .flatMap(json => HttpTransport.extractWeather[Current](json))
     weather.map(_.main.humidity) must beRight(62)
   }
 
   def e4 = {
     val weather = parse(Source.fromURL(getClass.getResource("/forecast.json")).mkString)
-      .flatMap(HttpTransport.extractWeather[Forecast])
+      .flatMap(json => HttpTransport.extractWeather[Forecast](json))
     weather.map(_.cod) must beRight("200")
   }
 
   def e5 = {
     val weather = parse(Source.fromURL(getClass.getResource("/empty.json")).mkString)
-      .flatMap(HttpTransport.extractWeather[History])
+      .flatMap(json => HttpTransport.extractWeather[History](json))
     weather.map(_.cod) must beLeft
   }
 
   def e6 = {
     val weather = parse(Source.fromURL(getClass.getResource("/nodata.json")).mkString)
-      .flatMap(HttpTransport.extractWeather[History])
+      .flatMap(json => HttpTransport.extractWeather[History](json))
     weather.map(_.cod) must beLeft(ErrorResponse(Some("404"), "no data"))
   }
 }

--- a/src/test/scala/com.snowplowanalytics.weather/providers/openweather/OwmClientSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.weather/providers/openweather/OwmClientSpec.scala
@@ -13,8 +13,8 @@
 package com.snowplowanalytics.weather
 package providers.openweather
 
-// joda
-import org.joda.time.DateTime
+// java
+import java.time.ZonedDateTime
 
 // cats
 import cats.effect.IO
@@ -56,7 +56,7 @@ class OwmClientSpec(implicit val ec: ExecutionEnv) extends Specification with Mo
         "start" -> "1449774761" // "2015-12-10T19:12:41+00:00"
       )
     )
-    client.historyByCoords(0.00f, 0.00f, DateTime.parse("2015-12-11T02:12:41.000+07:00"))
+    client.historyByCoords(0.00f, 0.00f, ZonedDateTime.parse("2015-12-11T02:12:41.000+07:00"))
     there.was(1.times(transport).receive(eqTo(expectedRequest))(any()))
   }
 

--- a/src/test/scala/com.snowplowanalytics.weather/providers/openweather/ServerSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.weather/providers/openweather/ServerSpec.scala
@@ -28,7 +28,7 @@ import org.scalacheck.Prop.forAll
 // This library
 import providers.TestData
 import Errors.AuthorizationError
-import CacheUtils.Position
+import Cache.Position
 
 object ServerSpec {
   val owmKey = sys.env.get("OWM_KEY")

--- a/src/test/scala/com.snowplowanalytics.weather/providers/openweather/WeatherGenerator.scala
+++ b/src/test/scala/com.snowplowanalytics.weather/providers/openweather/WeatherGenerator.scala
@@ -17,7 +17,7 @@ import org.scalacheck._
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen._
 import Responses._
-import CacheUtils._
+import Cache._
 import com.snowplowanalytics.weather.providers.TestData
 
 /**
@@ -127,8 +127,8 @@ trait WeatherGenerator {
    *
    * @return timestamp in seconds
    */
-  def genLastWeekTimeStamp: Gen[Int] = {
-    val now: Int = (System.currentTimeMillis() / 1000).toInt
+  def genLastWeekTimeStamp: Gen[Long] = {
+    val now = System.currentTimeMillis() / 1000
     for {
       seed <- Gen.choose(86400 * 2, 1209600) // Between yesterday and two weeks back
     } yield now - seed

--- a/src/test/scala/com.snowplowanalytics.weather/providers/openweather/WeatherGenerator.scala
+++ b/src/test/scala/com.snowplowanalytics.weather/providers/openweather/WeatherGenerator.scala
@@ -64,7 +64,7 @@ trait WeatherGenerator {
     } yield MainInfo(grndLevel, humidity, pressure, seaLevel, temp, tempMin, tempMax)
 
   // 12 Feb 2015 - 01 Dec 2016
-  def genTimestamp: Gen[Int] = Gen.choose(1423729852, 1480582792)
+  def genTimestamp: Gen[Long] = Gen.choose(1423729852, 1480582792)
 
   def genWeatherDescription: Gen[List[WeatherCondition]] =
     for {


### PR DESCRIPTION
Those two commits packed together because both are related to cache refactor. The cache is now abstracted a bit to the `Cache` class (with functions moved form `CacheUtils` to `Cache` companion object).